### PR TITLE
Reconfigured relationships to store objectId in followers/following

### DIFF
--- a/Models/PFUser+ExtendedUser.h
+++ b/Models/PFUser+ExtendedUser.h
@@ -31,8 +31,7 @@
 - (void)retrieveFavoritesWithCompletion:(void(^)(NSArray<GMSPlace*>*))completion;
 - (void)retrieveWishlistWithCompletion:(void(^)(NSArray<GMSPlace*>*))completion;
 - (void)follow:(PFUser *)user;
-- (void)addUserToFollowers:(PFUser*) user;
-- (void)addUserToFollowing:(PFUser*) user;
 - (void)retrieveRelationshipWithCompletion:(void(^)(Relationships*))completion;
++ (PFUser *)retrieveUserWithId:(NSString *)userId;
 
 @end

--- a/Models/PFUser+ExtendedUser.m
+++ b/Models/PFUser+ExtendedUser.m
@@ -12,6 +12,7 @@
 @implementation PFUser (ExtendedUser)
 @dynamic displayName, hometown, bio, profilePicture, favorites, wishlist, relationships;
 
+
 - (void)addFavorite:(GMSPlace*)place {
     // check if place exists already
     [Place checkGMSPlaceExists:place
@@ -155,37 +156,42 @@
     }];
 }
 
-
-
-
-
 - (void)follow:(PFUser *)user {
 
     // get the Relationships object of the current user
     [self retrieveRelationshipWithCompletion:^(Relationships *myRelationship) {
         
-        self.relationships = myRelationship;
-        NSString *objectId = myRelationship.objectId;
-        
         // get the array of users the current user is following
-        [Relationships retrieveFollowingWithId:objectId WithCompletion:^(NSArray *following) {
+        [Relationships retrieveFollowingWithId:self.relationships.objectId WithCompletion:^(NSArray *following) {
             
             self.relationships.following = [NSMutableArray arrayWithArray:following];
             
-            [myRelationship addUserToFollowing:user];
+            [myRelationship addUserIdToFollowing:user.objectId];
         }];
     }];
     
-    [self retrieveRelationshipWithCompletion:^(Relationships *userRelationship) {
+    
+    
+    [user retrieveRelationshipWithCompletion:^(Relationships *userRelationship) {
         
-        user.relationships = userRelationship;
-        NSString *objectId = userRelationship.objectId;
-        
-        [Relationships retrieveFollowersWithId:objectId WithCompletion:^(NSArray *followers) {
+        // get the array of user's followers
+        [Relationships retrieveFollowersWithId:user.relationships.objectId WithCompletion:^(NSArray *followers) {
             
-            [userRelationship addUserToFollowers:self];
+            [userRelationship addUserIdToFollowers:self.objectId];
+            
+            
         }];
+        
     }];
-    
 }
+
++ (PFUser *)retrieveUserWithId:(NSString *)userId {
+    
+    PFQuery *query = [PFUser query];
+    [query whereKey:@"objectId" equalTo:userId];
+    PFUser *user = [[query findObjects] objectAtIndex:0];
+    
+    return user;
+}
+
 @end

--- a/Models/Relationships.h
+++ b/Models/Relationships.h
@@ -11,8 +11,8 @@
 
 @interface Relationships : PFObject<PFSubclassing>
 
-@property (strong, nonatomic, nonnull) NSMutableArray *following;
-@property (strong, nonatomic, nonnull) NSMutableArray *followers;
+@property (strong, nonatomic, nonnull) NSArray<NSString *> *following;
+@property (strong, nonatomic, nonnull) NSArray<NSString *> *followers;
 
 + (void)getUsersWithCompletion:(void (^_Nonnull)(NSArray *users))completion;
 
@@ -20,8 +20,8 @@
 
 + (void)retrieveFollowingWithId:(NSString *)objectId WithCompletion: (void (^)(NSArray * following))completion;
 
-- (void)addUserToFollowing:(PFUser*) user;
+- (void)addUserIdToFollowing:(NSString*) userId;
 
-- (void)addUserToFollowers:(PFUser*) user;
+- (void)addUserIdToFollowers:(NSString*) userId;
 
 @end

--- a/Models/Relationships.m
+++ b/Models/Relationships.m
@@ -46,26 +46,31 @@
     }];
 }
 
-- (void)addUserToFollowing:(PFUser*) user {
+
+
+- (void)addUserIdToFollowing:(NSString*) userId {
     
-    if (![self.following containsObject:user]) {
-        [self.following addObject:user];
+    // get objectId of use
+    if (![self.following containsObject:userId]) {
+        
+        NSMutableArray *mutableFollowing = [NSMutableArray arrayWithArray:self.following];
+        [mutableFollowing addObject:userId];
+        self.following = [NSArray arrayWithArray:mutableFollowing];
         [self setObject:self.following forKey:@"following"];
     }
     [self saveInBackground];
 }
 
-- (void)addUserToFollowers:(PFUser*) user {
+- (void)addUserIdToFollowers:(NSString*) userId {
     
-    if (![self.followers containsObject:user]) {
-        [self.followers addObject:user];
+    if (![self.followers containsObject:userId]) {
+        
+        NSMutableArray *mutableFollowers = [NSMutableArray arrayWithArray:self.followers];
+        [mutableFollowers addObject:userId];
+        self.followers = [NSArray arrayWithArray:mutableFollowers];
         [self setObject:self.followers forKey:@"followers"];
     }
     [self saveInBackground];
 }
-
-
-
-
 
 @end

--- a/View Controllers/SearchResultsViewController.m
+++ b/View Controllers/SearchResultsViewController.m
@@ -96,8 +96,11 @@
         // get array of users that current user is following
         [Relationships retrieveFollowingWithId:relationships.objectId WithCompletion:^(NSArray *following) {
             
-            for (PFUser *user in following) {
-
+            for (NSString *userId in following) {
+                
+                // get the user that has id userId
+                PFUser *user = [PFUser retrieveUserWithId:userId];
+                
                 // get the favorites of each user
                 [user retrieveFavoritesWithCompletion:^(NSArray<GMSPlace *> *places) {
                     


### PR DESCRIPTION
Parse was only allowing us to save other PFUsers occasionally (still not sure why...). Edited relationships so that now the objectId of the user is saved instead of a pointer to the user.