### PR TITLE
Fix profile relationships

### DIFF
--- a/Models/PFUser+ExtendedUser.h
+++ b/Models/PFUser+ExtendedUser.h
@@ -33,5 +33,6 @@
 - (void)follow:(PFUser *)user;
 - (void)retrieveRelationshipWithCompletion:(void(^)(Relationships*))completion;
 + (PFUser *)retrieveUserWithId:(NSString *)userId;
++ (void)retrieveUsersWithIDs:(NSArray<NSString*>*)IDs withCompletion:(void(^)(NSArray<PFUser*>*))completion;
 
 @end

--- a/Models/PFUser+ExtendedUser.m
+++ b/Models/PFUser+ExtendedUser.m
@@ -194,4 +194,30 @@
     return user;
 }
 
++ (void)retrieveUsersWithIDs:(NSArray<NSString*>*)IDs withCompletion:(void(^)(NSArray<PFUser*>*))completion {
+    NSMutableArray<PFUser*>* users = [NSMutableArray new];
+    
+    // loop through all IDs
+    for(NSString* ID in IDs)
+    {
+        PFQuery* query = [PFUser query];
+        
+        // query the ID
+        [query getObjectInBackgroundWithId:ID
+               block:^(PFObject * _Nullable object, NSError * _Nullable error)
+               {
+                   if(object != nil)
+                   {
+                       [users addObject:(PFUser*)object];
+                   }
+                   
+                   // if our users array's length is the same as the IDs, then we are done
+                   if(users.count == IDs.count)
+                   {
+                       completion((NSArray*)users);
+                   }
+               }
+         ];
+    }
+}
 @end

--- a/View Controllers/ProfileViewController.m
+++ b/View Controllers/ProfileViewController.m
@@ -215,7 +215,12 @@
         [Relationships retrieveFollowersWithId:self.user.relationships.objectId 
                        WithCompletion:^(NSArray *following)
                        {
-                           [vc setUsers:following];
+                           [PFUser retrieveUsersWithIDs:following
+                                   withCompletion:^(NSArray<PFUser*>* users)
+                                   {
+                                       [vc setUsers:users];
+                                   }
+                            ];
                        }
          ];
     }
@@ -225,7 +230,12 @@
         [Relationships retrieveFollowingWithId:self.user.relationships.objectId
                        WithCompletion:^(NSArray *followers)
                        {
-                           [vc setUsers:followers];
+                           [PFUser retrieveUsersWithIDs:followers
+                                   withCompletion:^(NSArray<PFUser*>* users)
+                                   {
+                                       [vc setUsers:users];
+                                   }
+                            ];
                        }
          ];
     }


### PR DESCRIPTION
Updated the profile VC and relationships VC to work with the updated Relationships Parse object; before we were storing PFUser pointers in Relationships, but now we are storing their IDs instead.