### PR TITLE
Notifications Helper (NEED OPINIONS)

### DIFF
--- a/Helpers/NCHelper.h
+++ b/Helpers/NCHelper.h
@@ -1,0 +1,21 @@
+//
+//  NCHelper.h
+//  social-maps
+//
+//  Created by César Francisco Barraza on 7/23/18.
+//  Copyright © 2018 Bevin Benson. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum NotificationType : NSUInteger
+{
+    NTAddFavorite,
+    NTAddToWishlist
+}
+NotificationType;
+
+@interface NCHelper : NSObject
++ (void)addObserver:(nonnull id)observer type:(NotificationType)type selector:(SEL)selector;
++ (void)notify:(NotificationType)type object:(nullable id)object;
+@end

--- a/Helpers/NCHelper.h
+++ b/Helpers/NCHelper.h
@@ -11,7 +11,8 @@
 typedef enum NotificationType : NSUInteger
 {
     NTAddFavorite,
-    NTAddToWishlist
+    NTAddToWishlist,
+    NTNewFollow
 }
 NotificationType;
 

--- a/Helpers/NCHelper.m
+++ b/Helpers/NCHelper.m
@@ -1,0 +1,33 @@
+//
+//  NCHelper.m
+//  social-maps
+//
+//  Created by César Francisco Barraza on 7/23/18.
+//  Copyright © 2018 Bevin Benson. All rights reserved.
+//
+
+#import "NCHelper.h"
+
+@implementation NCHelper
++ (void)addObserver:(nonnull id)observer type:(NotificationType)type selector:(SEL)selector {
+    NSString* notification = [NCHelper stringWithNotificationType:type];
+    [[NSNotificationCenter defaultCenter] addObserver:observer selector:selector name:notification object:nil];
+}
+
++ (void)notify:(NotificationType)type object:(nullable id)object {
+    NSString* notification = [NCHelper stringWithNotificationType:type];
+    [[NSNotificationCenter defaultCenter] postNotificationName:notification object:object];
+}
+
++ (NSString*)stringWithNotificationType:(NotificationType)type {
+    switch(type)
+    {
+        case NTAddFavorite:
+            return @"AddFavoriteNotification";
+        case NTAddToWishlist:
+            return @"AddToWishlistNotification";
+    }
+    
+    return @"";
+}
+@end

--- a/Helpers/NCHelper.m
+++ b/Helpers/NCHelper.m
@@ -26,6 +26,8 @@
             return @"AddFavoriteNotification";
         case NTAddToWishlist:
             return @"AddToWishlistNotification";
+        case NTNewFollow:
+            return @"NewFollowNotification";
     }
     
     return @"";

--- a/Helpers/NCHelper.m
+++ b/Helpers/NCHelper.m
@@ -30,6 +30,8 @@
             return @"NewFollowNotification";
     }
     
+    // throw an exception if we get here. It means there's no string equivalent of the NT.
+    [NSException raise:@"Could not find NT enum string equivalent." format:@"'%lu' Notification Type has no string equivalent in 'stringWithNotificationType' method. NSNotificationCenter will fail.", type];
     return @"";
 }
 @end

--- a/View Controllers/ProfileViewController.m
+++ b/View Controllers/ProfileViewController.m
@@ -114,22 +114,16 @@
         [self.followingLabel setText:[NSString stringWithFormat:@"%lu following", relationship.following.count]];
     }];
 
-    //  add notification listener for adding to favorites
-    [NCHelper addObserver:self type:NTAddFavorite selector:@selector(addToFavorites:)];
-//    [[NSNotificationCenter defaultCenter] addObserver:self
-//                                             selector:@selector(addToFavorites:)
-//                                                 name:@"AddFavoriteNotification"
-//                                               object:nil];
-
-    // add notification listener for adding to wishlist
-    [NCHelper addObserver:self type:NTAddToWishlist selector:@selector(addToWishlist:)];
-//    [[NSNotificationCenter defaultCenter] addObserver:self
-//                                             selector:@selector(addToWishlist:)
-//                                                 name:@"AddToWishlistNotification"
-//                                               object:nil];
+    // add NC observers
+    [self addNotificationObservers];
     
     // set UI styles
     [self initUIStyles];
+}
+
+- (void)addNotificationObservers {
+    [NCHelper addObserver:self type:NTAddFavorite selector:@selector(addToFavorites:)];
+    [NCHelper addObserver:self type:NTAddToWishlist selector:@selector(addToWishlist:)];
 }
 
 - (void)setUser:(PFUser*)user {

--- a/View Controllers/ProfileViewController.m
+++ b/View Controllers/ProfileViewController.m
@@ -17,6 +17,7 @@
 #import "ProfileListCell.h"
 #import "RelationshipsViewController.h"
 #import "Relationships.h"
+#import "NCHelper.h"
 
 @interface ProfileViewController () <CLLocationManagerDelegate, GMSMapViewDelegate, UITableViewDataSource, UITableViewDelegate>
 // Outlet Definitions //
@@ -114,16 +115,18 @@
     }];
 
     //  add notification listener for adding to favorites
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(addToFavorites:)
-                                                 name:@"AddFavoriteNotification"
-                                               object:nil];
+    [NCHelper addObserver:self type:NTAddFavorite selector:@selector(addToFavorites:)];
+//    [[NSNotificationCenter defaultCenter] addObserver:self
+//                                             selector:@selector(addToFavorites:)
+//                                                 name:@"AddFavoriteNotification"
+//                                               object:nil];
 
     // add notification listener for adding to wishlist
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(addToWishlist:)
-                                                 name:@"AddToWishlistNotification"
-                                               object:nil];
+    [NCHelper addObserver:self type:NTAddToWishlist selector:@selector(addToWishlist:)];
+//    [[NSNotificationCenter defaultCenter] addObserver:self
+//                                             selector:@selector(addToWishlist:)
+//                                                 name:@"AddToWishlistNotification"
+//                                               object:nil];
     
     // set UI styles
     [self initUIStyles];

--- a/View Controllers/SearchResultsViewController.m
+++ b/View Controllers/SearchResultsViewController.m
@@ -10,7 +10,7 @@
 #import "DetailsViewController.h"
 #import "SearchCell.h"
 #import "ResultsTableViewController.h"
-
+#import "NCHelper.h"
 
 @interface SearchResultsViewController () <CLLocationManagerDelegate, ResultsViewDelegate, GMSMapViewDelegate>
 
@@ -32,17 +32,21 @@
     self.definesPresentationContext = true;
     
     //add notification listener for adding to favorites
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(addToFavorites:)
-                                                 name:@"AddFavoriteNotification"
-                                               object:nil];
-    // add notification listener for adding to wishlist
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(addToWishlist:)
-                                                 name:@"AddToWishlistNotification"
-                                               object:nil];
+    [NCHelper addObserver:self type:NTAddFavorite selector:@selector(addToFavorites:)];
+//    [[NSNotificationCenter defaultCenter] addObserver:self
+//                                             selector:@selector(addToFavorites:)
+//                                                 name:@"AddFavoriteNotification"
+//                                               object:nil];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(addPinsOfNewFollow:) name:@"NewFollowNotification" object:nil];
+    // add notification listener for adding to wishlist
+    [NCHelper addObserver:self type:NTAddToWishlist selector:@selector(addToWishlist:)];
+//    [[NSNotificationCenter defaultCenter] addObserver:self
+//                                             selector:@selector(addToWishlist:)
+//                                                 name:@"AddToWishlistNotification"
+//                                               object:nil];
+    
+    [NCHelper addObserver:self type:NTNewFollow selector:@selector(addPinsOfNewFollow:)];
+    //[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(addPinsOfNewFollow:) name:@"NewFollowNotification" object:nil];
     
     [self initMap];
     [self initSearch];

--- a/View Controllers/SearchResultsViewController.m
+++ b/View Controllers/SearchResultsViewController.m
@@ -31,26 +31,17 @@
 - (void)viewDidLoad {
     self.definesPresentationContext = true;
     
-    //add notification listener for adding to favorites
-    [NCHelper addObserver:self type:NTAddFavorite selector:@selector(addToFavorites:)];
-//    [[NSNotificationCenter defaultCenter] addObserver:self
-//                                             selector:@selector(addToFavorites:)
-//                                                 name:@"AddFavoriteNotification"
-//                                               object:nil];
-    
-    // add notification listener for adding to wishlist
-    [NCHelper addObserver:self type:NTAddToWishlist selector:@selector(addToWishlist:)];
-//    [[NSNotificationCenter defaultCenter] addObserver:self
-//                                             selector:@selector(addToWishlist:)
-//                                                 name:@"AddToWishlistNotification"
-//                                               object:nil];
-    
-    [NCHelper addObserver:self type:NTNewFollow selector:@selector(addPinsOfNewFollow:)];
-    //[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(addPinsOfNewFollow:) name:@"NewFollowNotification" object:nil];
-    
+    [self addNotificationObservers];
     [self initMap];
     [self initSearch];
 }
+
+- (void)addNotificationObservers {
+    [NCHelper addObserver:self type:NTAddFavorite selector:@selector(addToFavorites:)];
+    [NCHelper addObserver:self type:NTAddToWishlist selector:@selector(addToWishlist:)];
+    [NCHelper addObserver:self type:NTNewFollow selector:@selector(addPinsOfNewFollow:)];
+}
+
 - (void)initMap {
     
     // init our location

--- a/Views/PlaceResultCell.m
+++ b/Views/PlaceResultCell.m
@@ -71,7 +71,6 @@
                                 {
                                     [[PFUser currentUser] addFavorite:place];
                                     [NCHelper notify:NTAddFavorite object:place];
-                                    //[[NSNotificationCenter defaultCenter] postNotificationName:@"AddFavoriteNotification" object:place];
                                 }
          ];
     }];
@@ -84,7 +83,6 @@
                                 {
                                     [[PFUser currentUser] addToWishlist:place];
                                     [NCHelper notify:NTAddToWishlist object:place];
-                                    //[[NSNotificationCenter defaultCenter] postNotificationName:@"AddToWishlistNotification" object:place];
                                 }
          ];
     }];

--- a/Views/PlaceResultCell.m
+++ b/Views/PlaceResultCell.m
@@ -10,6 +10,7 @@
 #import "Place.h"
 #import "APIManager.h"
 #import "PFUser+ExtendedUser.h"
+#import "NCHelper.h"
 
 @implementation PlaceResultCell
 
@@ -69,7 +70,8 @@
                                 withCompletion:^(GMSPlace *place)
                                 {
                                     [[PFUser currentUser] addFavorite:place];
-                                    [[NSNotificationCenter defaultCenter] postNotificationName:@"AddFavoriteNotification" object:place];
+                                    [NCHelper notify:NTAddFavorite object:place];
+                                    //[[NSNotificationCenter defaultCenter] postNotificationName:@"AddFavoriteNotification" object:place];
                                 }
          ];
     }];
@@ -81,7 +83,8 @@
                                 withCompletion:^(GMSPlace *place)
                                 {
                                     [[PFUser currentUser] addToWishlist:place];
-                                    [[NSNotificationCenter defaultCenter] postNotificationName:@"AddToWishlistNotification" object:place];
+                                    [NCHelper notify:NTAddToWishlist object:place];
+                                    //[[NSNotificationCenter defaultCenter] postNotificationName:@"AddToWishlistNotification" object:place];
                                 }
          ];
     }];

--- a/Views/UserResultCell.m
+++ b/Views/UserResultCell.m
@@ -8,6 +8,7 @@
 
 #import "UserResultCell.h"
 #import "ParseImageHelper.h"
+#import "NCHelper.h"
 
 @implementation UserResultCell
 
@@ -36,7 +37,8 @@
     
     PFUser *currentUser = [PFUser currentUser];
     [currentUser follow:self.user];
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"NewFollowNotification" object:self.user];
+    [NCHelper notify:NTNewFollow object:self.user];
+    //[[NSNotificationCenter defaultCenter] postNotificationName:@"NewFollowNotification" object:self.user];
 }
 
 @end

--- a/social-maps.xcodeproj/project.pbxproj
+++ b/social-maps.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		317B3939210267900057079A /* SearchPage.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 317B3938210267900057079A /* SearchPage.storyboard */; };
 		317B393E210267E40057079A /* RelationshipListCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 317B393D210267E40057079A /* RelationshipListCell.m */; };
 		340E6CCEA9D6E4EE79FB3144 /* libPods-social-maps.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0669C073917F375AFFBB6F32 /* libPods-social-maps.a */; };
+		9E3C98312106F051002C63F5 /* NCHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E3C98302106F051002C63F5 /* NCHelper.m */; };
 		9E4D281C20FEBE090069CBF2 /* SignUpView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E4D281B20FEBE090069CBF2 /* SignUpView.storyboard */; };
 		9E4D281F20FEBE130069CBF2 /* SignUpViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E4D281E20FEBE130069CBF2 /* SignUpViewController.m */; };
 		9E6755E521012DF10056D009 /* ProfileListCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E6755E421012DF10056D009 /* ProfileListCell.m */; };
@@ -89,6 +90,8 @@
 		317B3938210267900057079A /* SearchPage.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SearchPage.storyboard; sourceTree = "<group>"; };
 		317B393C210267E40057079A /* RelationshipListCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelationshipListCell.h; sourceTree = "<group>"; };
 		317B393D210267E40057079A /* RelationshipListCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelationshipListCell.m; sourceTree = "<group>"; };
+		9E3C982F2106F051002C63F5 /* NCHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCHelper.h; sourceTree = "<group>"; };
+		9E3C98302106F051002C63F5 /* NCHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NCHelper.m; sourceTree = "<group>"; };
 		9E4D281B20FEBE090069CBF2 /* SignUpView.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SignUpView.storyboard; sourceTree = "<group>"; };
 		9E4D281D20FEBE120069CBF2 /* SignUpViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SignUpViewController.h; sourceTree = "<group>"; };
 		9E4D281E20FEBE130069CBF2 /* SignUpViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SignUpViewController.m; sourceTree = "<group>"; };
@@ -236,6 +239,8 @@
 				9EE973F0210280F60056DCF2 /* ImageHelper.m */,
 				9EE973F2210281850056DCF2 /* ParseImageHelper.h */,
 				9EE973F3210281850056DCF2 /* ParseImageHelper.m */,
+				9E3C982F2106F051002C63F5 /* NCHelper.h */,
+				9E3C98302106F051002C63F5 /* NCHelper.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -392,6 +397,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E3C98312106F051002C63F5 /* NCHelper.m in Sources */,
 				018E6A9D20FEBA6E00DE10A6 /* ListViewController.m in Sources */,
 				9EF4E3D220FD2AED005535C6 /* APIManager.m in Sources */,
 				9EF4E3D720FE6D95005535C6 /* ProfileViewController.m in Sources */,
@@ -558,14 +564,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = QR8BU78FBL;
 				DEVELOPMENT_TEAM = 4H789JND9X;
 				INFOPLIST_FILE = "social-maps/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bevin.socialmaps;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fb.socialmaps;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -578,14 +582,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = QR8BU78FBL;
 				DEVELOPMENT_TEAM = 4H789JND9X;
 				INFOPLIST_FILE = "social-maps/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bevin.socialmaps;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fb.socialmaps;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
This is a new helper class that serves as some kind of wrapper for the NSNotificationCenter.

Using NSNotificationCenter as normal requires longer method calls and requires providing a string from the receiving and sending part, which can sometimes be tedious and confusing...not to mention using different names accidentally on both ends can lead to unexpected behavior that can be hard to debug.

This class aims to solve those problems by providing shorter method names, and providing an enum with all the possible notifications our app may need to manage. Adding a type is as simple as expanding the enum and providing a new string for that type in the "stringWithNotificationType" method.

Take a look at the "Replaced all uses of NSNotificationCernter with NCHelper's methods." commit; I updated the default use of NSNotificationCenter with the new class, and I left the old code commented out so that you can see the difference. Let me know what y'all think.