### PR TITLE
changed checkIns to hold user objectids instead of PFUsers

### DIFF
--- a/Models/Place.h
+++ b/Models/Place.h
@@ -13,7 +13,7 @@
 // Instance Properties //
 @property (strong, nonatomic, nonnull) NSString *placeID;
 @property (strong, nonatomic, nullable) NSString *placeName;
-@property (strong, nonatomic, nullable) NSArray <PFUser*> *checkIns;
+@property (strong, nonatomic, nullable) NSArray <NSString*> *checkIns;
 
 - (nonnull instancetype)initWithGMSPlace:(nonnull GMSPlace*)place;
 - (void) didCheckIn:(nonnull PFUser *)user;

--- a/Models/Place.m
+++ b/Models/Place.m
@@ -74,7 +74,7 @@
 }
 
 - (void)didCheckIn:(PFUser *)user {
-    [self addObject:user forKey:@"checkIns"];
+    [self addObject:user.objectId forKey:@"checkIns"];
     [self saveInBackground];
 }
 

--- a/Storyboards/DetailsView.storyboard
+++ b/Storyboards/DetailsView.storyboard
@@ -181,9 +181,6 @@
         <namedColor name="VTR_GrayLabel">
             <color red="0.65098039215686276" green="0.65098039215686276" blue="0.65098039215686276" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <namedColor name="VTR_GrayLabel">
-            <color red="0.65098039215686276" green="0.65098039215686276" blue="0.65098039215686276" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
         <namedColor name="VTR_Main">
             <color red="1" green="0.60392156862745094" blue="0.47058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Storyboards/ResultsView.storyboard
+++ b/Storyboards/ResultsView.storyboard
@@ -138,7 +138,6 @@
                                         <color key="backgroundColor" name="VTR_Background"/>
                                         <connections>
                                             <outlet property="addressLabel" destination="0tw-1j-HJD" id="4dH-E8-2yh"/>
-                                            <outlet property="favoriteButton" destination="bJ5-9f-OPr" id="6NN-BE-LDz"/>
                                             <outlet property="nameLabel" destination="qG7-df-OFj" id="YvQ-Rq-z0B"/>
                                         </connections>
                                     </tableViewCell>


### PR DESCRIPTION
Parse won't correctly store PFUsers in an object, so we had to store the PFUser objectIds instead. This commit changed the arrays to store objectId strings for the users who checked in.