### PR TITLE
Added scroll view to search page

### DIFF
--- a/APIs/APIManager.h
+++ b/APIs/APIManager.h
@@ -25,5 +25,6 @@
 - (void)getAllGMSPlaces:(void(^)(NSArray<GMSPlace*>* places))completion;
 - (void)getAllUsers:(void(^)(NSArray<PFUser*>* users))completion;
 - (void)getPhotoMetadata:(NSString *)placeID :(void(^)(NSArray<GMSPlacePhotoMetadata *> *photoMetadata))completion;
+- (void)getNextGMSPlacesBatch:(void(^)(NSArray<GMSPlace *> *places))completion;
 
 @end


### PR DESCRIPTION
This branch adds a new method to the APIManager that queries a fixed number of places from Parse, rather than returning all the places, and returns them in the order that they were added to the database. It also adds a scroll view to the search page so that the next ten places are queried from Parse when the user scrolls to the bottom of the page.